### PR TITLE
fix: update ec-validador-cedula-ruc to v2.0.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": "^8.2",
-        "tavo1987/ec-validador-cedula-ruc": "^2.0",
+        "tavo1987/ec-validador-cedula-ruc": "^2.0.1",
         "illuminate/validation": "^11.0|^12.0",
         "illuminate/support": "^11.0|^12.0"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ed8d0a2a0733fa2c76904847fbdbe0f6",
+    "content-hash": "08bb01528aa5b08beaf874090db5383b",
     "packages": [
         {
             "name": "brick/math",
@@ -5581,16 +5581,16 @@
         },
         {
             "name": "tavo1987/ec-validador-cedula-ruc",
-            "version": "v2.0.0",
+            "version": "v2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/tavo1987/ec-validador-cedula-ruc.git",
-                "reference": "182effcca0cf0e47963e469c652bb457a08ed135"
+                "reference": "a97cc0bd2afd4fbf199456f3bfaec0e5a416bec5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/tavo1987/ec-validador-cedula-ruc/zipball/182effcca0cf0e47963e469c652bb457a08ed135",
-                "reference": "182effcca0cf0e47963e469c652bb457a08ed135",
+                "url": "https://api.github.com/repos/tavo1987/ec-validador-cedula-ruc/zipball/a97cc0bd2afd4fbf199456f3bfaec0e5a416bec5",
+                "reference": "a97cc0bd2afd4fbf199456f3bfaec0e5a416bec5",
                 "shasum": ""
             },
             "require": {
@@ -5633,9 +5633,9 @@
             ],
             "support": {
                 "issues": "https://github.com/tavo1987/ec-validador-cedula-ruc/issues",
-                "source": "https://github.com/tavo1987/ec-validador-cedula-ruc/tree/v2.0.0"
+                "source": "https://github.com/tavo1987/ec-validador-cedula-ruc/tree/v2.0.1"
             },
-            "time": "2026-01-07T23:05:06+00:00"
+            "time": "2026-01-08T21:58:24+00:00"
         },
         {
             "name": "tijsverkoyen/css-to-inline-styles",

--- a/readme.md
+++ b/readme.md
@@ -95,6 +95,14 @@ class StoreClientRequest extends FormRequest
 }
 ```
 
+## What's New in v3.0.1
+
+### Bug Fixes
+
+- Updated `ec-validador-cedula-ruc` to v2.0.1
+- Fixed validation for private company RUCs (`ruc_spriv`) with 7-digit extended sequential numbers
+- Per SRI rules, RUCs exceeding 999999 in sequential value no longer require modulo 11 check digit validation
+
 ## What's New in v3.0.0
 
 ### Breaking Changes


### PR DESCRIPTION
## Summary
- Updated `ec-validador-cedula-ruc` dependency to v2.0.1
- Fixed validation for private company RUCs (`ruc_spriv`) with 7-digit extended sequential numbers
- Per SRI rules, RUCs exceeding 999999 in sequential value no longer require modulo 11 check digit validation

## Test plan
- [x] Run `composer update tavo1987/ec-validador-cedula-ruc`
- [x] Run `./vendor/bin/phpunit` - all 9 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)